### PR TITLE
chore: update RELEASE_VERSION to 6.4. in workflow

### DIFF
--- a/.github/workflows/metasploit-framework.yml
+++ b/.github/workflows/metasploit-framework.yml
@@ -14,7 +14,7 @@ permissions:
   security-events: write
 
 env:
-  RELEASE_VERSION: "6.4.41"
+  RELEASE_VERSION: "6.4.47"
   RUBY_VERSION: "3.2.5"
   
 jobs:


### PR DESCRIPTION
### **User description**
Updates the RELEASE_VERSION in the GitHub Actions workflow file  to 6.4.47 to reflect the latest version of the Metasploit  Framework. This ensures that the workflow uses the most recent  release for builds and deployments.


___

### **PR Type**
enhancement


___

### **Description**
- Updated `RELEASE_VERSION` in GitHub Actions workflow to `6.4.47`.

- Ensures the workflow uses the latest Metasploit Framework release.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>metasploit-framework.yml</strong><dd><code>Update RELEASE_VERSION in workflow environment variables</code>&nbsp; </dd></summary>
<hr>

.github/workflows/metasploit-framework.yml

<li>Updated <code>RELEASE_VERSION</code> from <code>6.4.41</code> to <code>6.4.47</code>.<br> <li> Ensures the workflow reflects the latest Metasploit Framework version.


</details>


  </td>
  <td><a href="https://github.com/matusso/docker-builds/pull/8/files#diff-7ba11af700150493337456751f855ba076be68915ae40336495859bd3bed1bf6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>