### PR TITLE
ci(workflows): build on main branch and version tags

### DIFF
--- a/.github/workflows/caddy.yml
+++ b/.github/workflows/caddy.yml
@@ -2,8 +2,9 @@ name: Build Caddy (xcaddy) and Publish
 
 on:
   push:
-    tags:
+    branches:
       - main
+    tags:
       - caddy-v*.*.* # build on version tags like v1.0.0
   workflow_dispatch:
 


### PR DESCRIPTION
### **User description**
- Update CI workflow triggers to include the main branch
- Add trigger for version tags matching the caddy-v*.*.* pattern
- Ensure pushes to main run the workflow while still allowing release builds for version tags like caddy-v1.0.0


___

### **PR Type**
Other


___

### **Description**
- Update CI workflow triggers to include main branch

- Add version tag pattern matching for caddy-v*.*.*

- Enable both continuous integration and release builds


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Push to main branch"] --> C["CI Workflow Triggered"]
  B["Push version tag caddy-v*.*.*"] --> C
  D["Manual workflow_dispatch"] --> C
  C --> E["Build Caddy with xcaddy"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>caddy.yml</strong><dd><code>Configure CI triggers for branches and tags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/caddy.yml

<ul><li>Add main branch to push triggers<br> <li> Restructure triggers to include both branches and tags<br> <li> Maintain existing version tag pattern caddy-v*.*.*</ul>


</details>


  </td>
  <td><a href="https://github.com/matusso/docker-builds/pull/15/files#diff-e658431af8ef0557c3dd982c23d0b0a391931cf65c314b5960c560ec7ad8692e">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

