### PR TITLE
build(ci): derive image version from CADDY_VERSION env var

### DIFF
--- a/.github/workflows/caddy.yml
+++ b/.github/workflows/caddy.yml
@@ -123,11 +123,7 @@ jobs:
       - name: Compute tags
         id: meta
         run: |
-          VERSION=${GITHUB_REF##*/}
-          if [[ "${GITHUB_REF}" != refs/tags/* ]]; then
-            VERSION="sha-${GITHUB_SHA::7}"
-          fi
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "version=${{ env.CADDY_VERSION }}" >> $GITHUB_OUTPUT
           echo "tags=${{ env.IMAGE_NAME }}:${VERSION},${{ env.IMAGE_NAME }}:latest" >> $GITHUB_OUTPUT
 
       - name: Build & push


### PR DESCRIPTION
### **User description**
Update GitHub Actions workflow to compute the image version using
the predefined CADDY_VERSION environment variable instead of parsing
GITHUB_REF or falling back to a short SHA. This simplifies tag
generation and ensures the intended Caddy release/version is used for
both the specific tag and latest tag when building and pushing images.

Adjust tags output to reference the computed VERSION variable so the
IMAGE_NAME:<version> and IMAGE_NAME:latest tags remain consistent.


___

### **PR Type**
Enhancement


___

### **Description**
- Simplify image version computation using `CADDY_VERSION` environment variable

- Remove complex tag parsing logic from GitHub Actions workflow

- Ensure consistent versioning for Docker image tags


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CADDY_VERSION env var"] --> B["Compute tags step"]
  B --> C["Docker image tags"]
  C --> D["IMAGE_NAME:version"]
  C --> E["IMAGE_NAME:latest"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>caddy.yml</strong><dd><code>Simplify version computation using environment variable</code>&nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/caddy.yml

<ul><li>Replace complex version parsing logic with direct <code>CADDY_VERSION</code> usage<br> <li> Remove conditional logic for tag vs non-tag refs<br> <li> Simplify version computation to single line assignment</ul>


</details>


  </td>
  <td><a href="https://github.com/matusso/docker-builds/pull/16/files#diff-e658431af8ef0557c3dd982c23d0b0a391931cf65c314b5960c560ec7ad8692e">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

