### PR TITLE
chore(ci): scope workflow triggers and fix caddy image name

### DIFF
--- a/.github/workflows/caddy.yml
+++ b/.github/workflows/caddy.yml
@@ -17,10 +17,11 @@ permissions:
 env:
   # Change this if you want a different package name in GHCR
   APP_SLUG: caddy
-  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/${{ github.repository }}_${{ github.env.APP_SLUG }}
+  CADDY_VERSION: "v2.10.2"
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/${{ github.repository }}${APP_SLUG}-${CADDY_VERSION}
   CADDY_MODULES: github.com/caddy-dns/cloudflare
   GO_VERSION: "1.22"
-  CADDY_VERSION: "v2.10.2"
+  
 
 concurrency:
   # Avoid overlapping pushes from the same branch racing


### PR DESCRIPTION
### **User description**
Limit workflow run triggers to relevant workflow and files to avoid
unnecessary executions on unrelated pushes or PR events. Update the
push/pull_request configuration for thorium and wpscan workflows to use
paths filtering (workflow file and respective files/* directories).

Standardize Caddy image naming and move CADDY_VERSION earlier in the
env block. Construct IMAGE_NAME using repository owner/name, app slug,
and CADDY_VERSION to produce a more descriptive image tag. Also remove
duplicate CADDY_VERSION entry and clean up spacing.


___

### **PR Type**
Other


___

### **Description**
- Fix Caddy Docker image naming convention

- Move CADDY_VERSION environment variable positioning

- Clean up duplicate variable definitions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old IMAGE_NAME"] --> B["New IMAGE_NAME"]
  C["CADDY_VERSION moved up"] --> B
  D["Duplicate removed"] --> E["Clean env block"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>caddy.yml</strong><dd><code>Fix image naming and env variable organization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/caddy.yml

<ul><li>Moved <code>CADDY_VERSION</code> variable earlier in env block<br> <li> Updated <code>IMAGE_NAME</code> construction to use proper syntax with APP_SLUG and <br>CADDY_VERSION<br> <li> Removed duplicate <code>CADDY_VERSION</code> entry<br> <li> Added spacing for better readability</ul>


</details>


  </td>
  <td><a href="https://github.com/matusso/docker-builds/pull/19/files#diff-e658431af8ef0557c3dd982c23d0b0a391931cf65c314b5960c560ec7ad8692e">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

