### PR TITLE
chore(ci): publish Caddy packages to GHCR with per-arch artifacts

### DIFF
--- a/.github/workflows/caddy.yml
+++ b/.github/workflows/caddy.yml
@@ -1,13 +1,11 @@
-name: Build Caddy (xcaddy)
+name: Publish Caddy Packages (xcaddy -> GHCR generic)
 
 on:
   push:
-    branches:
-      - "main"
+    branches: [ "main" ]
     paths:
       - .github/workflows/caddy.yml
       - "files/caddy/**"
-
   workflow_dispatch:
 
 permissions:
@@ -15,23 +13,20 @@ permissions:
   packages: write
 
 env:
-  # Change this if you want a different package name in GHCR
+  # ---- customize here ----
   APP_SLUG: caddy
   CADDY_VERSION: "v2.10.2"
-  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/${{ github.repository }}${APP_SLUG}-${CADDY_VERSION}
   CADDY_MODULES: github.com/caddy-dns/cloudflare
   GO_VERSION: "1.22"
-  
+  # ------------------------
 
 concurrency:
-  # Avoid overlapping pushes from the same branch racing
   group: caddy-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  # ---------- Build native binaries (per-platform artifacts) ----------
-  build-binaries:
-    name: Build ${{ matrix.osarch }}
+  build-and-publish:
+    name: Build & publish ${{ matrix.osarch }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -40,16 +35,13 @@ jobs:
           - goos: linux
             goarch: amd64
             osarch: linux-amd64
-            suffix: x86_64
           - goos: linux
             goarch: arm64
             osarch: linux-arm64
-            suffix: arm64
           - goos: linux
             goarch: arm
             goarm: 7
             osarch: linux-armv7
-            suffix: armv7
 
     steps:
       - uses: actions/checkout@v4
@@ -71,91 +63,85 @@ jobs:
       - name: Install xcaddy
         run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
 
-      - name: Compute safe branch slug
-        id: branch
+      - name: Compute metadata
+        id: meta
         run: |
-          # turn "feature/my-branch" into "feature-my-branch"
           SAFE_BRANCH="$(echo "${GITHUB_REF_NAME}" | tr '/' '-' )"
-          echo "safe=${SAFE_BRANCH}" >> "$GITHUB_OUTPUT"
+          SHORTSHA="${GITHUB_SHA::7}"
+          MOD_SLUG="$(basename "${{ env.CADDY_MODULES }}")"   # e.g. cloudflare
+          echo "branch=${SAFE_BRANCH}"    >> $GITHUB_OUTPUT
+          echo "shortsha=${SHORTSHA}"     >> $GITHUB_OUTPUT
+          echo "modslug=${MOD_SLUG}"      >> $GITHUB_OUTPUT
 
-      - name: Build caddy with Cloudflare (${{ matrix.osarch }})
+      - name: Build caddy (${{ matrix.osarch }})
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           GOARM: ${{ matrix.goarm }}
         run: |
           mkdir -p dist
-          BIN="caddy-${{ steps.branch.outputs.safe }}-${{ matrix.osarch }}"
-          $(go env GOPATH)/bin/xcaddy build ${{ env.CADDY_VERSION }}\
+          BIN="caddy-${{ steps.meta.outputs.branch }}-${{ matrix.osarch }}"
+          $(go env GOPATH)/bin/xcaddy build ${{ env.CADDY_VERSION }} \
             --output "dist/${BIN}" \
             --with ${{ env.CADDY_MODULES }}
           chmod +x "dist/${BIN}"
-
           pushd dist >/dev/null
           sha256sum "${BIN}" > "${BIN}.sha256"
           tar -czf "${BIN}.tar.gz" "${BIN}"
           popd >/dev/null
 
-      - name: Upload per-platform artifact (unique per branch + arch)
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.APP_SLUG }}-${{ steps.branch.outputs.safe }}-${{ matrix.osarch }}
-          path: |
-            dist/caddy-${{ steps.branch.outputs.safe }}-${{ matrix.osarch }}
-            dist/caddy-${{ steps.branch.outputs.safe }}-${{ matrix.osarch }}.sha256
-            dist/caddy-${{ steps.branch.outputs.safe }}-${{ matrix.osarch }}.tar.gz
-          if-no-files-found: error
-          retention-days: 14
-
-  # ---------- Build & push multi-arch Docker image to GHCR ----------
-  docker:
-    name: Push GHCR image (multi-arch)
-    runs-on: ubuntu-latest
-    needs: build-binaries
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - name: Install ORAS
+        run: |
+          curl -sSfL https://github.com/oras-project/oras/releases/latest/download/oras_$(uname -s | tr '[:upper:]' '[:lower:]')_amd64.tar.gz \
+          | tar -xzC /usr/local/bin oras
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Compute tags from branch
-        id: meta
         run: |
-          SAFE_BRANCH="$(echo "${GITHUB_REF_NAME}" | tr '/' '-' )"
-          SHORTSHA="${GITHUB_SHA::7}"
-          echo "branch=${SAFE_BRANCH}" >> $GITHUB_OUTPUT
-          echo "shortsha=${SHORTSHA}" >> $GITHUB_OUTPUT
-          echo "tags=${{ env.IMAGE_NAME }}:${SAFE_BRANCH},${{ env.IMAGE_NAME }}:${SAFE_BRANCH}-${SHORTSHA}" >> $GITHUB_OUTPUT
+          echo "${{ secrets.GITHUB_TOKEN }}" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
 
-      - name: Write Dockerfile
+      - name: Push package to GHCR (${{ matrix.osarch }})
+        env:
+          PKG_REPO: ghcr.io/${{ github.repository_owner }}/${{ github.repository }}
         run: |
-          cat > Dockerfile <<'EOF'
-          FROM caddy:builder AS builder
-          # Build custom caddy with Cloudflare module
-          RUN xcaddy build ${{ env.CADDY_VERSION }} --with github.com/caddy-dns/cloudflare
-          FROM caddy:latest
-          COPY --from=builder /usr/bin/caddy /usr/bin/caddy
-          # COPY Caddyfile /etc/caddy/Caddyfile  # uncomment if present in repo
-          EOF
+          FILE="dist/caddy-${{ steps.meta.outputs.branch }}-${{ matrix.osarch }}.tar.gz"
+          SHA="dist/caddy-${{ steps.meta.outputs.branch }}-${{ matrix.osarch }}.sha256"
 
-      - name: Build & push (linux/amd64, arm64, arm/v7)
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: |
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.title=${{ env.APP_SLUG }}
-            org.opencontainers.image.ref.name=${{ steps.meta.outputs.branch }}
-          provenance: false
-          sbom: false
+          # Repository path will look like:
+          # ghcr.io/<owner>/<repo>/<app>-<module>
+          REPO="${PKG_REPO}/${{ env.APP_SLUG }}-${{ steps.meta.outputs.modslug }}"
+
+          # Tag example:
+          # v2.10.2-linux-amd64-main-abc1234
+          TAG="${{ env.CADDY_VERSION }}-${{ matrix.osarch }}-${{ steps.meta.outputs.branch }}-${{ steps.meta.outputs.shortsha }}"
+
+          # Main artifact
+          oras push "${REPO}:${TAG}" \
+            "${FILE}:application/octet-stream" \
+            --annotation "org.opencontainers.image.title=${{ env.APP_SLUG }}" \
+            --annotation "org.opencontainers.image.description=Custom Caddy with ${{ env.CADDY_MODULES }} for ${{ matrix.osarch }}" \
+            --annotation "org.opencontainers.image.version=${{ env.CADDY_VERSION }}" \
+            --annotation "org.opencontainers.image.revision=${{ github.sha }}" \
+            --annotation "org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}" \
+            --annotation "caddy.module=${{ env.CADDY_MODULES }}" \
+            --annotation "caddy.osarch=${{ matrix.osarch }}" \
+            --annotation "caddy.branch=${{ steps.meta.outputs.branch }}"
+
+          # Optional: publish checksum as a side artifact
+          oras push "${REPO}:${TAG}-sha256" \
+            "${SHA}:text/plain"
+
+      # (Optional) Also push easy-to-consume rolling tags
+      - name: Push rolling tags (latest per arch & branch)
+        if: ${{ success() }}
+        env:
+          PKG_REPO: ghcr.io/${{ github.repository_owner }}/${{ github.repository }}
+        run: |
+          FILE="dist/caddy-${{ steps.meta.outputs.branch }}-${{ matrix.osarch }}.tar.gz"
+          REPO="${PKG_REPO}/${{ env.APP_SLUG }}-${{ steps.meta.outputs.modslug }}"
+
+          # latest for this branch + arch (e.g., latest-linux-amd64-main)
+          oras push "${REPO}:latest-${{ matrix.osarch }}-${{ steps.meta.outputs.branch }}" \
+            "${FILE}:application/octet-stream" \
+            --annotation "caddy.module=${{ env.CADDY_MODULES }}" \
+            --annotation "caddy.osarch=${{ matrix.osarch }}" \
+            --annotation "caddy.branch=${{ steps.meta.outputs.branch }}"


### PR DESCRIPTION
### **User description**
Rename and refactor the xcaddy workflow to publish packaged Caddy artifacts
to GitHub Container Registry (GHCR) in a generic, discoverable format.

- Change workflow name and trigger formatting; keep main branch trigger.
- Consolidate jobs into a single build-and-publish job that builds per-arch
  binaries and publishes artifacts.
- Compute richer metadata (branch slug, short commit SHA, module slug)
  and use them in output filenames to create stable, unique package names.
- Produce dist/{bin,sha256,tar.gz} for each platform and standardize binary
  naming as caddy-<branch>-<osarch>.
- Remove separate Docker multi-arch build job and replace with GHCR publish
  flow using ORAS for pushing generic packages.
- Add GHCR login and streamline tag computation and publishing steps.
- Tidy env block with customization hint and removed unused IMAGE_NAME.

These changes make releases reproducible, uniquely scoped by branch+sha,
and enable publishing pre-built Caddy packages to GHCR for consumption.


___

### **PR Type**
Enhancement


___

### **Description**
- Refactor CI workflow to publish Caddy packages to GHCR

- Replace Docker multi-arch build with ORAS generic packages

- Add per-architecture artifact publishing with metadata

- Consolidate jobs and improve naming conventions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Build xcaddy binaries"] --> B["Generate metadata"]
  B --> C["Create tar.gz + sha256"]
  C --> D["Login to GHCR"]
  D --> E["Push packages via ORAS"]
  E --> F["Push rolling tags"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>caddy.yml</strong><dd><code>Refactor CI workflow for GHCR package publishing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/caddy.yml

<ul><li>Rename workflow from "Build Caddy (xcaddy)" to "Publish Caddy <br>Packages"<br> <li> Consolidate separate build and Docker jobs into single <br><code>build-and-publish</code> job<br> <li> Replace Docker multi-arch build with ORAS-based GHCR package <br>publishing<br> <li> Add metadata computation for branch slug, short SHA, and module slug<br> <li> Remove artifact upload step and add GHCR login with ORAS push commands<br> <li> Add rolling tag publishing for latest per-arch packages</ul>


</details>


  </td>
  <td><a href="https://github.com/matusso/docker-builds/pull/20/files#diff-e658431af8ef0557c3dd982c23d0b0a391931cf65c314b5960c560ec7ad8692e">+66/-80</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

