### PR TITLE
fix(ci): restrict workflow triggers and improve caddy artifacts

### DIFF
--- a/.github/workflows/caddy.yml
+++ b/.github/workflows/caddy.yml
@@ -2,13 +2,17 @@ name: Publish Caddy Binaries to Release
 
 on:
   push:
-    tags:
-      - "v*"            # e.g., v2.10.2
-      - "caddy-v*"      # optional: caddy-v2.10.2
+    branches:
+      - main
+    paths:
+      - '.github/workflows/caddy.yml'
+      - 'files/caddy/**'
   workflow_dispatch:     # manual run support
 
 permissions:
   contents: write        # needed to create/update releases
+  packages: write
+  security-events: write
 
 env:
   APP_SLUG: caddy
@@ -90,12 +94,18 @@ jobs:
           tar -czf "${BIN}.tar.gz" "${BIN}"
           popd >/dev/null
 
+      - name: List build outputs
+        run: |
+          echo "Contents of dist/:"
+          ls -lah dist || true
       - name: Upload artifact (${{ matrix.osarch }})
         uses: actions/upload-artifact@v4
         with:
           name: caddy-build-${{ matrix.osarch }}
           path: |
-            dist/${{ env.APP_SLUG }}-${{ matrix.osarch }}-${{ steps.meta.outputs.modslug }}-* # tar.gz + bin + sha256
+            dist/${{ env.APP_SLUG }}-${{ matrix.osarch }}-${{ steps.meta.outputs.modslug }}-*.tar.gz
+            dist/${{ env.APP_SLUG }}-${{ matrix.osarch }}-${{ steps.meta.outputs.modslug }}-*.sha256
+            dist/${{ env.APP_SLUG }}-${{ matrix.osarch }}-${{ steps.meta.outputs.modslug }}-*
           if-no-files-found: error
           retention-days: 7
 


### PR DESCRIPTION
### **User description**
Narrow workflow trigger scopes for thorium and wpscan so pushes
only for main are considered and workflows run when their files or
related assets change. Limit caddy workflow to pushes on main and
specific file paths instead of tags, and add workflow_dispatch for
manual runs.

Adjust caddy permissions to allow package and security-events writes,
so release and publish steps can run successfully. Improve artifact
upload: list build outputs for debugging and explicitly upload .tar.gz
and .sha256 files (and any other matching build outputs), avoiding
ambiguous globs that previously missed expected files.


___

### **PR Type**
Enhancement


___

### **Description**
- Restrict workflow triggers to main branch pushes only

- Add specific file path filters for targeted execution

- Improve artifact upload with explicit file patterns

- Add debugging output for build artifacts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Tag-based triggers"] --> B["Branch-based triggers"]
  B --> C["Path-filtered execution"]
  C --> D["Enhanced permissions"]
  D --> E["Improved artifact upload"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>caddy.yml</strong><dd><code>Refactor workflow triggers and artifact handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/caddy.yml

<ul><li>Changed trigger from tags to main branch pushes with path filters<br> <li> Added packages and security-events write permissions<br> <li> Added debugging step to list build outputs<br> <li> Replaced wildcard artifact paths with explicit file patterns</ul>


</details>


  </td>
  <td><a href="https://github.com/matusso/docker-builds/pull/22/files#diff-e658431af8ef0557c3dd982c23d0b0a391931cf65c314b5960c560ec7ad8692e">+14/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

