### PR TITLE
chore(ci): simplify release naming and set constant title

### DIFF
--- a/.github/workflows/caddy.yml
+++ b/.github/workflows/caddy.yml
@@ -78,7 +78,7 @@ jobs:
           # final binary name: caddy-<osarch>-<module>-<tag or version>
           VER="${{ steps.meta.outputs.tag }}"
           [ -z "$VER" ] && VER="${{ env.CADDY_VERSION }}"
-          BIN="${{ env.APP_SLUG }}-${{ matrix.osarch }}-${{ steps.meta.outputs.modslug }}-${VER}"
+          BIN="${{ env.APP_SLUG }}-${{ matrix.osarch }}-${VER}"
 
           $(go env GOPATH)/bin/xcaddy build ${{ env.CADDY_VERSION }} \
             --output "dist/${BIN}" \
@@ -118,8 +118,7 @@ jobs:
           TAG="${GITHUB_REF_NAME}"
           [ -z "$TAG" ] && TAG="${{ env.CADDY_VERSION }}"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          # Optional release title like "Caddy custom (v2.10.2)"
-          echo "title=Caddy custom (${TAG})" >> "$GITHUB_OUTPUT"
+          echo "title=Caddy ${{ env.CADDY_VERSION }}" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release (if not exists) & upload assets
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
### **User description**
Update the CI release workflow to produce a shorter binary name by removing
the module slug from the artifact filename. The BIN variable now uses only
app slug, os/arch matrix and version, avoiding the extra module segment.
This keeps artifact names concise and consistent across builds.

Also standardize the GitHub Release title to the configured CADDY_VERSION
instead of a constructed "Caddy custom (vX)" string. This makes release
titles predictable and tied to the explicit version variable used in the
workflow.


___

### **PR Type**
Other


___

### **Description**
- Simplify binary naming by removing module slug

- Standardize release title to use CADDY_VERSION


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Binary naming"] --> B["Remove module slug"]
  C["Release title"] --> D["Use CADDY_VERSION"]
  B --> E["Shorter artifact names"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>caddy.yml</strong><dd><code>Simplify release naming and titles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/caddy.yml

<ul><li>Remove <code>${{ steps.meta.outputs.modslug }}</code> from BIN variable<br> <li> Change release title from constructed string to <code>CADDY_VERSION</code><br> <li> Simplify artifact naming pattern</ul>


</details>


  </td>
  <td><a href="https://github.com/matusso/docker-builds/pull/23/files#diff-e658431af8ef0557c3dd982c23d0b0a391931cf65c314b5960c560ec7ad8692e">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

