### PR TITLE
ci: add workflow to build RAPTOR image

### DIFF
--- a/.github/workflows/raptor.yml
+++ b/.github/workflows/raptor.yml
@@ -1,0 +1,69 @@
+name: gadievron/raptor
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/raptor.yml"
+  schedule:
+    - cron: "17 3 * * 0"
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: raptor-image
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout RAPTOR source
+        uses: actions/checkout@v4
+        with:
+          repository: gadievron/raptor
+          ref: main
+          path: raptor
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Resolve source metadata
+        id: source
+        run: |
+          echo "sha_short=$(git -C raptor rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
+          echo "sha_full=$(git -C raptor rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push RAPTOR image
+        uses: docker/build-push-action@v6
+        with:
+          context: raptor
+          file: raptor/.devcontainer/Dockerfile
+          # Upstream devcontainer bundles linux64 CodeQL and documents rr as x86_64-only.
+          platforms: linux/amd64
+          pull: true
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/raptor:latest
+            ghcr.io/${{ github.repository_owner }}/raptor:sha-${{ steps.source.outputs.sha_short }}
+          labels: |
+            org.opencontainers.image.title=raptor
+            org.opencontainers.image.description=RAPTOR devcontainer image built from gadievron/raptor
+            org.opencontainers.image.source=https://github.com/gadievron/raptor
+            org.opencontainers.image.revision=${{ steps.source.outputs.sha_full }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Add GitHub Actions workflow to build and push RAPTOR
devcontainer image to GitHub Container Registry. The workflow
builds the image from the upstream gadievron/raptor repository
and tags it with both latest and commit SHA identifiers. It
runs on schedule weekly, on workflow dispatch, and when the
workflow file itself changes.