### PR TITLE
feat: optimize wafw00f and add arm64 support

### DIFF
--- a/.github/workflows/raptor.yml
+++ b/.github/workflows/raptor.yml
@@ -48,16 +48,45 @@ jobs:
 
           from_old = "FROM mcr.microsoft.com/devcontainers/python:1-3.12-bookworm"
           from_new = "FROM mcr.microsoft.com/devcontainers/python:3.12-bookworm"
+          gconf_old = "    libgconf-2-4 \\\n"
           env_old = 'ENV PYTHONPATH="/workspaces/raptor:/workspaces/raptor/packages:${PYTHONPATH}"'
           env_new = 'ARG PYTHONPATH=""\nENV PYTHONPATH="/workspaces/raptor:/workspaces/raptor/packages:${PYTHONPATH}"'
+          codeql_old = (
+              "ARG CODEQL_VERSION=2.15.5\n"
+              "RUN mkdir -p /opt/codeql \\\n"
+              '    && curl -L "https://github.com/github/codeql-cli-binaries/releases/download/v${CODEQL_VERSION}/codeql-linux64.zip" -o /tmp/codeql.zip \\\n'
+              "    && unzip /tmp/codeql.zip -d /opt \\\n"
+              "    && rm /tmp/codeql.zip \\\n"
+              "    && ln -s /opt/codeql/codeql /usr/local/bin/codeql"
+          )
+          codeql_new = (
+              "ARG CODEQL_VERSION=2.15.5\n"
+              "ARG TARGETARCH\n"
+              "RUN mkdir -p /opt/codeql \\\n"
+              '    && if [ "$TARGETARCH" = "amd64" ]; then \\\n'
+              '         curl -L "https://github.com/github/codeql-cli-binaries/releases/download/v${CODEQL_VERSION}/codeql-linux64.zip" -o /tmp/codeql.zip \\\n'
+              "         && unzip /tmp/codeql.zip -d /opt \\\n"
+              "         && rm /tmp/codeql.zip \\\n"
+              "         && ln -s /opt/codeql/codeql /usr/local/bin/codeql; \\\n"
+              "       else \\\n"
+              "         printf '#!/bin/sh\\necho \"CodeQL CLI is not bundled on %s; upstream releases only publish linux64 binaries.\" >&2\\nexit 1\\n' \"$TARGETARCH\" > /usr/local/bin/codeql \\\n"
+              "         && chmod +x /usr/local/bin/codeql; \\\n"
+              "       fi"
+          )
 
           if from_old not in text:
               raise SystemExit(f"Expected base image not found: {from_old}")
+          if gconf_old not in text:
+              raise SystemExit(f"Expected obsolete package line not found: {gconf_old!r}")
           if env_old not in text:
               raise SystemExit(f"Expected PYTHONPATH env line not found: {env_old}")
+          if codeql_old not in text:
+              raise SystemExit("Expected CodeQL install block not found")
 
           text = text.replace(from_old, from_new, 1)
+          text = text.replace(gconf_old, "", 1)
           text = text.replace(env_old, env_new, 1)
+          text = text.replace(codeql_old, codeql_new, 1)
 
           path.write_text(text)
           PY
@@ -72,13 +101,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Build and push RAPTOR image
         uses: docker/build-push-action@v6
         with:
           context: raptor
           file: raptor/.devcontainer/Dockerfile
-          # Upstream devcontainer bundles linux64 CodeQL and documents rr as x86_64-only.
-          platforms: linux/amd64
+          # arm64/v8 skips the bundled CodeQL CLI because upstream release assets are linux64-only.
+          platforms: linux/amd64,linux/arm64/v8
           pull: true
           push: true
           tags: |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The main goal is simple: keep commonly used tools available in `ghcr.io/matusso/
 | `metasploit-framework` | [rapid7/metasploit-framework](https://github.com/rapid7/metasploit-framework) | `6.4.128` | Full Metasploit Framework image built from the upstream repository and published as a multi-arch image. |
 | `mvt` | [mvt-project/mvt](https://github.com/mvt-project/mvt) | `v2.7.0` | Mobile Verification Toolkit CLI package. The image installs the pinned PyPI package and defaults to a shell because the toolkit exposes multiple commands. |
 | `pocketbase` | [pocketbase/pocketbase](https://github.com/pocketbase/pocketbase) | `v0.37.2` | PocketBase binary image for running the standalone backend service. The image downloads the correct release artifact for the target architecture. |
-| `raptor` | [gadievron/raptor](https://github.com/gadievron/raptor) | `main` | RAPTOR security research framework devcontainer image. It tracks upstream `main` and publishes `latest` plus `sha-<commit>` tags. Currently `linux/amd64` only. |
+| `raptor` | [gadievron/raptor](https://github.com/gadievron/raptor) | `main` | RAPTOR security research framework devcontainer image. It tracks upstream `main` and publishes `latest` plus `sha-<commit>` tags for `linux/amd64` and `linux/arm64/v8`. The bundled CodeQL CLI remains amd64-only because upstream release assets are linux64-only. |
 | `routersploit` | [threat9/routersploit](https://github.com/threat9/routersploit) | `v3.4.7` | Exploitation framework focused on embedded devices and router targets. Built with a local wrapper Dockerfile from the tagged upstream source. |
 | `wafw00f` | [EnableSecurity/wafw00f](https://github.com/EnableSecurity/wafw00f) | `v2.4.2` | Web application firewall fingerprinting tool. Built with a local wrapper Dockerfile from the tagged upstream source. |
 
@@ -70,6 +70,7 @@ Notes:
 - `pocketbase` exposes port `8080` and starts the PocketBase server by default.
 - `mvt` installs multiple CLI entrypoints, so the container defaults to `sh` rather than forcing a single command.
 - `raptor` is a development environment style image, not a minimal single-purpose runtime image.
+- On `linux/arm64/v8`, the `raptor` image skips the bundled CodeQL CLI because GitHub’s CodeQL CLI release assets are published as `linux64` only.
 
 ## Quality And Security Checks
 

--- a/files/wafw00f/Dockerfile
+++ b/files/wafw00f/Dockerfile
@@ -10,11 +10,9 @@ RUN apk update && apk add --no-cache git
 WORKDIR /app
 
 # Clone the wafw00f repository
-RUN git clone --branch "$RELEASE_VERSION" https://github.com/EnableSecurity/wafw00f .
+RUN git clone --depth=1 --branch "$RELEASE_VERSION" https://github.com/EnableSecurity/wafw00f .
 
-# Install any needed packages specified in requirements.txt
-RUN pip install setuptools
-
-RUN python setup.py install
+# Install wafw00f from the upstream pyproject-based package.
+RUN pip install --no-cache-dir .
 
 ENTRYPOINT [ "wafw00f" ]


### PR DESCRIPTION
Optimize wafw00f Dockerfile by using shallow clone and
installing from pyproject instead of setup.py. Add arm64
support to RAPTOR devcontainer with conditional CodeQL
installation for non-amd64 architectures. Remove obsolete
gconf dependency and update base image reference.